### PR TITLE
fix: category parsing edge case

### DIFF
--- a/scripts/ProtocolsTable.py
+++ b/scripts/ProtocolsTable.py
@@ -32,12 +32,14 @@ def parse_protocol_file(file_path: str) -> List[Dict[str, str]]:
 
         # Get first category or empty string if no categories
         categories = data.get('categories', [])
-        if categories:
-            first_category = categories[0]
-            parts = first_category.split('::')
-            type, subtype = parts[0], parts[1]
-        else:
+        if not categories:
             raise Exception(f"missing category for {name}")
+        first_category = categories[0]
+        parts = first_category.split('::')
+        if len(parts) < 2:
+            raise Exception(f"invalid category format '{first_category}' in {name}, expected 'type::subtype'")
+
+        type, subtype = parts[0], parts[1]
 
         # Get addresses
         addresses = data.get('addresses', {})


### PR DESCRIPTION
noticed category parsing assumes there’s always a `::` in the string - but if it’s missing, it crashes with an IndexError.
added a quick check to make sure both type and subtype exist before unpacking.
