### PR TITLE
Update Dirol_Protocol.json links

### DIFF
--- a/testnet/Dirol_Protocol.json
+++ b/testnet/Dirol_Protocol.json
@@ -8,7 +8,7 @@
         "LP2": "0xcb593bc54af3e7e46a4a562b6c0b14d5caf2869a"
     },
     "links": {
-        "project": "https://dex.dirol.network/swap",
+        "project": "https://dex.dirol.io/swap",
         "twitter": "https://x.com/DirolProtocol",
         "docs": "https://dirolprotocols-organization.gitbook.io/dirolprotocol"
     }


### PR DESCRIPTION
Corrected the project URL from https://dex.dirol.network/swap to https://dex.dirol.io/swap.