### PR TITLE
fix: update documentation link

### DIFF
--- a/testnet/Golden_Goose.json
+++ b/testnet/Golden_Goose.json
@@ -9,6 +9,6 @@
     "links": {
         "project": "https://www.goose.farm/",
         "twitter": "https://x.com/GoldenGoose_app",
-        "docs": "https://docs.goose.farm/golden-goose/what-is-golden-goose"
+        "docs": "https://docs.goose.farm/treasure-goose/readme"
     }
 }


### PR DESCRIPTION


Changes made:
- Updated docs URL from "https://docs.goose.farm/golden-goose/what-is-golden-goose" to "https://docs.goose.farm/treasure-goose/readme"

The change was necessary to point to the correct and working documentation endpoint.

