### PR TITLE
 Update Azaar docs link

### DIFF
--- a/testnet/Azaar.json
+++ b/testnet/Azaar.json
@@ -12,6 +12,6 @@
         "project": "https://azaar.com/",
         "twitter": "https://x.com/AzaarExchange",
         "github": "https://github.com/Azaar-Exchange/docs",
-        "docs": "https://azaar.org/docs/"
+        "docs": "https://azaarexchange.medium.com/"
     }
 }


### PR DESCRIPTION
I contacted the Azaar team — they confirmed the previous docs link (https://azaar.org/docs/) is outdated.
They provided the new location for documentation:
👉 https://azaaarexchange.medium.com/

Updated accordingly in Azaar.json.