### PR TITLE
fix not valid URL in Update Ammalgam.json

### DIFF
--- a/testnet/Ammalgam.json
+++ b/testnet/Ammalgam.json
@@ -10,7 +10,7 @@
         "AmmalgamFactory": "0xaB04bBa82c01a6635ec373979B75817A47519Af7"
     },
     "links": {
-        "project": "ammalgam.xyz",
+        "project": "https://ammalgam.xyz",
         "twitter": "https://x.com/Ammalgam",
         "github": "https://github.com/Ammalgam-Protocol",
         "docs": "https://docs.ammalgam.xyz/"


### PR DESCRIPTION
This PR fixes an issue in the Ammalgam protocol JSON where the "project" link was missing the required https:// protocol. Updated "project": "ammalgam.xyz"
⟶ "project": "https://ammalgam.xyz"

 Why this matters:
URLs without a protocol may break link rendering in browsers, markdown previews, API consumers, and automated validators.

Ensures consistency with other link fields (twitter, github, docs), which already include proper URL formatting.

Prevents potential runtime errors when these links are used programmatically (e.g., in data parsers, crawlers, or frontends).