### PR TITLE
Include SendMonad.com disperse utility 

### DIFF
--- a/testnet/SendMonad.json
+++ b/testnet/SendMonad.json
@@ -1,0 +1,13 @@
+{
+    "name": "SendMonad.com",
+    "description": "SendMonad.com is the first Monad Disperse utility that allows sending native MON tokens and ERC20 tokens to multiple addresses in one transaction. The protocol has enabled 25,000+ users to receive MON or ERC20 tokens on Monad testnet.",
+    "categories": [
+        "DeFi::Other"
+    ],
+    "addresses": {
+        "Contract": "0xd1513D1d9fCA6e2495b62898194aE2303D1726A5"
+    },
+    "links": {
+        "project": "https://www.sendmonad.com"
+    }
+}


### PR DESCRIPTION
### Summary

**This PR adds metadata for **SendMonad.com**, a disperse utility on Monad testnet.**  
It allows sending native MON tokens and ERC20 tokens to multiple addresses in a single transaction.  

### Added
- `testnet/sendmonad.json`

### Details
- **Name**: SendMonad.com  
- **Category**: `DeFi::Other`  
- **Contract**: `0xd1513D1d9fCA6e2495b62898194aE2303D1726A5`  
- **Contract Link**: [https://testnet.monadexplorer.com/address/0xd1513D1d9fCA6e2495b62898194aE2303D1726A5](https://testnet.monadexplorer.com/address/0xd1513D1d9fCA6e2495b62898194aE2303D1726A5)  
- **Project Link**: [https://www.sendmonad.com](https://www.sendmonad.com)

### Notes
- JSON validated with `jsonlint`  
- Categories follow the repo’s allowed list  
- Contract address checksummed  

### Context
SendMonad has already enabled **25,000+ users** to receive MON or ERC20 tokens on Monad testnet.  
This addition ensures it’s discoverable via the protocols registry.
