### PR TITLE
Update GitHub Actions setup-node to v5

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v5
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '18'
 


### PR DESCRIPTION
actions/setup-node from v4 → v5
Using the latest version ensures continued support, bug fixes, and compatibility improvements.

Official release: https://github.com/actions/setup-node/releases/tag/v5.0.0