### PR TITLE
Add Kodeus to monad mainnet

### DIFF
--- a/mainnet/Kodeus.json
+++ b/mainnet/Kodeus.json
@@ -1,0 +1,17 @@
+{
+    "name": "Kodeus",
+    "description": "Kodeus is the Internet's Agent Layer where users create programmable and monetizable agents that act, settle and prove autonomously",
+    "categories": [
+        "AI::Consumer AI"
+    ],
+    "addresses": {
+        "KodeusAgents": "0x3d3c1Db86989eD5196358eE03e2F1258EA183dCB",
+        "KodeusMetricsTrackerV6": "0xa0371d51C086f846Bd02c331DD31cc510645332e"
+    },
+    "links": {
+        "project": "https://kodeus.ai",
+        "twitter": "https://x.com/thekodeuslabs",
+        "github": "https://github.com/KodeusAI"
+    }
+}
+


### PR DESCRIPTION
Adding Kodeus Contracts to mainnet under AI::Consumer AI category
