### PR TITLE
Migrate testnet protocols from the docs

### DIFF
--- a/testnet/Axelar.jsonc
+++ b/testnet/Axelar.jsonc
@@ -1,0 +1,20 @@
+{
+    "name": "Axelar",
+    "description": "Powering the Chain-Agnostic Future",
+    "live": true,
+    "categories": ["Infra::Interoperability"],
+    "addresses": {
+        "AxelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
+        "AxelarGasService": "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
+        "MonadAxelarTransceiver": "0x50beAbe4883981624aEa01F737B040d1e3Fe83FB",
+        "Operators": "0x7F83F5cA2AE4206AbFf8a3C3668e88ce5F11C0B5",
+        "ConstAddressDeployer": "0x98B2920D53612483F91F12Ed7754E51b4A77919e",
+        "Create3Deployer": "0x6513Aedb4D1593BA12e50644401D976aebDc90d8"
+    },
+    "links": {
+        "project": "https://axelar.network",
+        "twitter": "https://x.com/axelar",
+        "github": "https://github.com/axelarnetwork",
+        "docs": "https://docs.axelar.dev"
+    }
+}

--- a/testnet/Chainlink_CCIP.jsonc
+++ b/testnet/Chainlink_CCIP.jsonc
@@ -1,0 +1,18 @@
+{
+    "name": "Chainlink CCIP",
+    "description": "Chainlink is the standard for onchain finance, verifiable data, and cross-chain interoperability. Learn more by visiting chain.link.",
+    "live": true,
+    "categories": ["Infra::Interoperability"],
+    "addresses": {
+        "Router": "0x5f16e51e3Dcb255480F090157DD01bA962a53E54"
+    },
+    "info": {
+        "note": "Supported lanes can be found at https://docs.chain.link/ccip/directory/testnet/chain/monad-testnet"
+    },
+    "links": {
+        "project": "https://chain.link/",
+        "twitter": "https://x.com/chainlink",
+        "github": "https://github.com/smartcontractkit/chainlink",
+        "docs": "https://docs.chain.link/"
+    }
+}

--- a/testnet/Hyperlane.json
+++ b/testnet/Hyperlane.json
@@ -1,11 +1,13 @@
 {
     "name": "Hyperlane",
     "description": "Hyperlane is a permissionless interoperability protocol for cross-chain message passing & asset transfers. It's fast, free, and open-source!",
-    "live": false,
+    "live": true,
     "categories": [
         "Infra::Interoperability"
     ],
-    "addresses": {},
+    "addresses": {
+        "ISMOperator": "0x734628f55694d2a5f4de3e755ccb40ecd72b16d9"
+    },
     "links": {
         "project": "https://hyperlane.xyz",
         "twitter": "https://x.com/hyperlane",

--- a/testnet/LayerZero.json
+++ b/testnet/LayerZero.json
@@ -4,13 +4,16 @@
     "live": true,
     "categories": ["Infra::Interoperability"],
     "addresses": {
-        "unknown0": "0x6C7Ab2202C98C4227C5c46f1417D81144DA716Ff",
-        "unknown1": "0xd682ECF100f6F4284138AA925348633B0611Ae21",
-        "unknown2": "0xcF1B0F4106B0324F96fEfcC31bA9498caa80701C",
-        "unknown3": "0xB0487596a0B62D1A71D0C33294bd6eB635Fc6B09",
-        "unknown4": "0x073f5b4FdF17BBC16b0980d49f6C56123477bb51",
-        "unknown5": "0x926984a57b10a3a5c4cfdbac04daaa0309e78932",
-        "unknown6": "0x9dB9Ca3305B48F196D18082e91cB64663b13d014"
+        "EndpointV2": "0x6C7Ab2202C98C4227C5c46f1417D81144DA716Ff",
+        "SendUln302": "0xd682ECF100f6F4284138AA925348633B0611Ae21",
+        "ReceiveUln302": "0xcF1B0F4106B0324F96fEfcC31bA9498caa80701C",
+        "BlockedMessageLib": "0x926984a57b10a3a5c4cfdbac04daaa0309e78932",
+        "LZExecutor": "0x9dB9Ca3305B48F196D18082e91cB64663b13d014",
+        "LZDeadDVN": "0xF49d162484290EAeAd7bb8C2c7E3a6f8f52e32d6"
+    },
+    "info": {
+        "endpointId": 40204,
+        "addressReference": "https://docs.layerzero.network/v2/deployments/deployed-contracts?chains=monad-testnet"
     },
     "links": {
         "project": "https://layerzero.network/",

--- a/testnet/Polymer.json
+++ b/testnet/Polymer.json
@@ -1,0 +1,15 @@
+{
+    "name": "Polymer",
+    "description": "Polymer is an interoperability protocol tailor made for multi-rollup applications.",
+    "live": true,
+    "categories": ["Infra::Interoperability"],
+    "addresses": {
+        "CrossL2Prover": "0xcDa03d74DEc5B24071D1799899B2e0653C24e5Fa"
+    },
+    "links": {
+        "project": "https://www.polymerlabs.org/",
+        "twitter": "https://x.com/polymerlabs",
+        "github": "https://github.com/polymerdao",
+        "docs": "https://docs.polymerlabs.org/"
+    }
+}

--- a/testnet/Wormhole.json
+++ b/testnet/Wormhole.json
@@ -5,7 +5,11 @@
     "categories": ["Infra::Interoperability"],
     "addresses": {
         "Core": "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd",
+        "TokenBridge": "0xF323dcDe4d33efe83cf455F78F9F6cc656e6B659",
         "Relayer": "0x362fca37E45fe1096b42021b543f462D49a5C8df"
+    },
+    "info": {
+        "wormholeChainId": 48
     },
     "links": {
         "project": "https://wormhole.com/",


### PR DESCRIPTION
To remove contract addresses from docs and keep protocols repo as the single source of truth, removed some contract addresses from the docs, and added them here.

Also opened a PR for docs: 488

