### PR TITLE
Add Formo

### DIFF
--- a/mainnet/formo.json
+++ b/mainnet/formo.json
@@ -6,7 +6,7 @@
     "Infra::Analytics"
   ],
   "addresses": {
-    "Formo": "0x7E6CA77a7E044BA836a97beB796c124Ca3a6A255"
+    "default": "0x7E6CA77a7E044BA836a97beB796c124Ca3a6A255"
   },
   "links": {
     "project": "https://formo.so",

--- a/mainnet/formo.json
+++ b/mainnet/formo.json
@@ -1,0 +1,18 @@
+{
+  "name": "Formo",
+  "description": "Crypto-native analytics platform combining product analytics, wallet intelligence, and onchain attribution for DeFi apps.",
+  "live": true,
+  "categories": [
+    "Infra::Analytics"
+  ],
+  "addresses": {
+    "Formo": "0x7E6CA77a7E044BA836a97beB796c124Ca3a6A255"
+  },
+  "links": {
+    "project": "https://formo.so",
+    "twitter": "https://x.com/getformo",
+    "github": "https://github.com/getformo",
+    "docs": "https://docs.formo.so",
+    "linkedin": "https://www.linkedin.com/company/getformo"
+  }
+}


### PR DESCRIPTION
[Formo](https://formo.so) makes analytics simple for DeFi apps so you can focus on growth. Get the best of web, product, and onchain analytics in one place.

We're live on Monad and would like to be listed on https://docs.monad.xyz/tooling-and-infra/analytics so more builders can discover us.