### PR TITLE
use json5 instead of jsoncomment in validation scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "Monad Token List"
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = ["json5>=0.12.1", "requests>=2.31.0", "jsoncomment>=0.4.2"]
+dependencies = ["json5>=0.12.1", "requests>=2.31.0"]
 
 [dependency-groups]
 dev = ["ruff>=0.14.4"]

--- a/scripts/check_verified_contracts.py
+++ b/scripts/check_verified_contracts.py
@@ -14,7 +14,6 @@ import argparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import glob
 import json
-from jsoncomment import JsonComment
 import os
 from pathlib import Path
 import requests
@@ -22,11 +21,11 @@ import sys
 import time
 from typing import Dict, List, Tuple
 
+import json5
+
 BLOCKVISION_API_BASE_URL = "https://api.blockvision.org/v2/monad/contract/source/code"
 REQUEST_DELAY = 0.2  # Delay between API requests (seconds)
 DEFAULT_WORKERS = 5  # Default number of parallel workers
-
-JSONC_PARSER = JsonComment(json)
 
 
 def parse_jsonc(file_path: str) -> dict:
@@ -40,8 +39,7 @@ def parse_jsonc(file_path: str) -> dict:
         Parsed JSON data as a dictionary
     """
     with open(file_path, "r", encoding="utf-8") as f:
-        content = f.read()
-        return JSONC_PARSER.loads(content)
+        return json5.load(f)
 
 
 def get_all_protocol_files() -> List[str]:
@@ -135,6 +133,15 @@ def process_file(file_path: str, blockvision_api_key: str) -> Dict:
     """
     try:
         data = parse_jsonc(file_path)
+    except ValueError as e:
+        return {
+            "file": file_path,
+            "status": "error",
+            "message": f"JSON parsing error: {str(e)}",
+            "results": {},
+        }
+
+    try:
         protocol_name = data.get("name", Path(file_path).stem)
         addresses = data.get("addresses", {})
 
@@ -163,13 +170,6 @@ def process_file(file_path: str, blockvision_api_key: str) -> Dict:
             "status": "success",
             "all_valid": all_valid,
             "results": results,
-        }
-    except json.JSONDecodeError as e:
-        return {
-            "file": file_path,
-            "status": "error",
-            "message": f"JSON parsing error: {str(e)}",
-            "results": {},
         }
     except Exception as e:
         return {

--- a/uv.lock
+++ b/uv.lock
@@ -130,52 +130,12 @@ wheels = [
 ]
 
 [[package]]
-name = "json-spec"
-version = "0.10.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "six", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/eb/3d294b939d5d314e4c9eba5ed958a2872c21f090ec9aa77aef9524308a71/json-spec-0.10.1.tar.gz", hash = "sha256:0b32fb0508d47115eccb4daa14731f101f1263fb57a8cb13ca49c960b05eb719", size = 85559, upload-time = "2017-01-10T13:45:52.87Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/38/e6705aa66e5f67d9b7b5d4123750ecdc151e1427ea48d5e3817feee01fdd/json_spec-0.10.1-py2.py3-none-any.whl", hash = "sha256:c30d7c8bee07bd3fdf620b8902398d0ab58c735adedfeff07e6a7fc358f8cbeb", size = 40691, upload-time = "2017-01-10T13:45:49.953Z" },
-]
-
-[[package]]
-name = "json-spec"
-version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/47/84e030fb7764bd716d2fb58d4bd45c006b407cd413f472a60f1e09265ceb/json_spec-0.12.0.tar.gz", hash = "sha256:0a1fe48bf3e6bce39668b4bacb99e479429138d77b16ab25c482b3238d4702e0", size = 29658, upload-time = "2024-04-29T11:55:55.958Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/7c/31574832b5269f7a9385cec3b9b19d0a535f5ace075446ca9cbb240868bc/json_spec-0.12.0-py3-none-any.whl", hash = "sha256:5096695f1ed4d2bf70b04bee792615cc36f8f830f5a5a2255fc43731e4deba1e", size = 42174, upload-time = "2024-04-29T11:55:54.01Z" },
-]
-
-[[package]]
 name = "json5"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/ae/929aee9619e9eba9015207a9d2c1c54db18311da7eb4dcf6d41ad6f0eb67/json5-0.12.1.tar.gz", hash = "sha256:b2743e77b3242f8d03c143dd975a6ec7c52e2f2afe76ed934e53503dd4ad4990", size = 52191, upload-time = "2025-08-12T19:47:42.583Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/e2/05328bd2621be49a6fed9e3030b1e51a2d04537d3f816d211b9cc53c5262/json5-0.12.1-py3-none-any.whl", hash = "sha256:d9c9b3bc34a5f54d43c35e11ef7cb87d8bdd098c6ace87117a7b7e83e705c1d5", size = 36119, upload-time = "2025-08-12T19:47:41.131Z" },
-]
-
-[[package]]
-name = "jsoncomment"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "json-spec", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "json-spec", version = "0.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/75/b5c7895b8d2edcecbc49b55adb10087183050f95eac33c3453cc12c610f1/jsoncomment-0.4.2.tar.gz", hash = "sha256:8fa065a85327306211ec567bb9ad8ca252c59332f6c6cf09c3228a0abf1191da", size = 9179, upload-time = "2019-02-08T00:15:14.649Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/9e/ec3da1601c7a5700e9e4229d5404e590107a1bbe50c78dbcfb33948177fc/jsoncomment-0.4.2-py3-none-any.whl", hash = "sha256:7ce82b755e54fdc0dc1c3c05e2bc7db0c3f609be31771401f78f00e743b0403e", size = 6846, upload-time = "2019-02-08T00:15:13.569Z" },
 ]
 
 [[package]]
@@ -220,21 +180,11 @@ wheels = [
 ]
 
 [[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
 name = "token-list"
 version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "json5" },
-    { name = "jsoncomment" },
     { name = "requests" },
 ]
 
@@ -246,7 +196,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "json5", specifier = ">=0.12.1" },
-    { name = "jsoncomment", specifier = ">=0.4.2" },
     { name = "requests", specifier = ">=2.31.0" },
 ]
 


### PR DESCRIPTION
json5:
* is already used in the rest of the package
* tolerates mid-line comments (vs jsoncomment which only allows them on newlines)

this reduces some false alarms in validation