### PR TITLE
Add avodex protocol listing

### DIFF
--- a/testnet/avodex.json
+++ b/testnet/avodex.json
@@ -9,6 +9,6 @@
     "addresses": {},
     "links": {
         "project": "https://avodex.ai",
-        "github": "https://github.com/TerpLayer"
+        "github": "https://github.com/avodex"
     }
 }

--- a/testnet/avodex.json
+++ b/testnet/avodex.json
@@ -1,0 +1,14 @@
+{
+    "name": "avodex",
+    "description": "Avodex is a spot and perpetuals DEX powered by its own in-house matching engine, with AI-powered grid-trading bots.",
+    "live": false,
+    "categories": [
+        "DeFi::DEX",
+        "DeFi::Perpetuals / Derivatives"
+    ],
+    "addresses": {},
+    "links": {
+        "project": "https://avodex.ai",
+        "github": "https://github.com/TerpLayer"
+    }
+}


### PR DESCRIPTION
Adds the ecosystem listing for **avodex** under `testnet/`.

- **Name:** avodex
- **Description:** spot & perpetuals DEX powered by its own in-house matching engine, with AI-powered grid-trading bots
- **Categories:** DeFi::DEX, DeFi::Perpetuals / Derivatives
- **Project:** https://avodex.ai
- **GitHub:** https://github.com/TerpLayer

`addresses` is intentionally empty / `live: false` for now — contract addresses will be added via a follow-up PR once deployed and verified on Monad.