### PR TITLE
Add avodex protocol listing

### DIFF
--- a/testnet/avodex.json
+++ b/testnet/avodex.json
@@ -1,0 +1,14 @@
+{
+    "name": "avodex",
+    "description": "Avodex is a spot and perpetuals DEX powered by its own in-house matching engine, with AI-powered grid-trading bots.",
+    "live": false,
+    "categories": [
+        "DeFi::DEX",
+        "DeFi::Perpetuals / Derivatives"
+    ],
+    "addresses": {},
+    "links": {
+        "project": "https://avodex.ai",
+        "github": "https://github.com/avodex"
+    }
+}


### PR DESCRIPTION
Adds `testnet/avodex.json` for the **avodex** protocol listing.

- **avodex** — a spot + perpetuals DEX powered by its own in-house matching engine, with AI-powered grid-trading bots.
- Project: https://avodex.ai
- GitHub: https://github.com/avodex
- `live: false`, `addresses: {}` until contracts deploy on Monad.