### PR TITLE
Add Gem Wallet mainnet metadata

### DIFF
--- a/mainnet/gem_wallet.jsonc
+++ b/mainnet/gem_wallet.jsonc
@@ -7,6 +7,6 @@
         "project": "https://gemwallet.com/",
         "twitter": "https://x.com/gemwalletcom",
         "github": "https://github.com/gemwalletcom/wallet",
-        "docs": "https://docs.gemwallet.com/"
+        "docs": "https://docs.gemwallet.com/blockchains/monad/"
     }
 }

--- a/mainnet/gem_wallet.jsonc
+++ b/mainnet/gem_wallet.jsonc
@@ -1,0 +1,12 @@
+{
+    "name": "Gem Wallet",
+    "description": "Gem Wallet is an open-source, self-custodial multichain wallet supporting Monad. Users can store, send, receive, buy, and swap assets while retaining full control of their private keys.",
+    "categories": ["Infra::Wallet"],
+    "addresses": {},
+    "links": {
+        "project": "https://gemwallet.com/",
+        "twitter": "https://x.com/gemwalletcom",
+        "github": "https://github.com/gemwalletcom",
+        "docs": "https://docs.gemwallet.com/"
+    }
+}

--- a/mainnet/gem_wallet.jsonc
+++ b/mainnet/gem_wallet.jsonc
@@ -6,7 +6,7 @@
     "links": {
         "project": "https://gemwallet.com/",
         "twitter": "https://x.com/gemwalletcom",
-        "github": "https://github.com/gemwalletcom",
+        "github": "https://github.com/gemwalletcom/wallet",
         "docs": "https://docs.gemwallet.com/"
     }
 }


### PR DESCRIPTION
## Summary

Adds Gem Wallet to the Monad protocols metadata under `Infra::Wallet`.

Gem Wallet supports Monad and we would also like this metadata to help with inclusion on the Monad Software Wallets documentation page:

https://docs.monad.xyz/tooling-and-infra/wallets/software-wallets

## References

- Gem Wallet: https://gemwallet.com/
- Monad integration page: https://gemwallet.com/learn/gem-wallet-integrates-monad-next-level-evm-blockchain-for-scale/
- Gem Wallet docs: https://docs.gemwallet.com/
- Ethereum.org wallet listing: https://ethereum.org/wallets/find-wallet/
- Latest related Ethereum.org PR: https://github.com/ethereum/ethereum-org-website/pull/18721

## Notes

No Monad contract addresses are included because Gem Wallet is wallet infrastructure rather than an onchain protocol deployment.

## Validation

Ran:

```bash
python scripts/validate_protocol.py --network mainnet --protocol gem_wallet
python scripts/validate_protocol.py --network mainnet
```

Both completed successfully. The validator reports the expected warning that `gem_wallet.jsonc` has an empty address map.
